### PR TITLE
Build absolute URLs

### DIFF
--- a/app/lib/base.php
+++ b/app/lib/base.php
@@ -189,7 +189,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$params=$this->parse($params);
 		if (empty($this->hive['ALIASES'][$name]))
 			user_error(sprintf(self::E_Named,$name),E_USER_ERROR);
-		$url=$this->build($this->hive['ALIASES'][$name],$params);
+		$url=rtrim($this->hive['REALM'],"/").$this->build($this->hive['ALIASES'][$name],$params);
 		return $url;
 	}
 


### PR DESCRIPTION
Previously if pathfinder wads installed at a url like localhost:8888/pathfinder/ urls built using this function were going to localhost:8888/somewhere instead of localhost:8888/pathfinder/somewhere.