### PR TITLE
Added quotes around "From" name to prevent F3 email parsing issues

### DIFF
--- a/app/main/controller/mailcontroller.php
+++ b/app/main/controller/mailcontroller.php
@@ -22,7 +22,7 @@ class MailController extends \SMTP{
         parent::__construct($host,$port,$scheme,$user,$pw);
 
         // error handling
-        $this->set('Errors-to', '' . Controller::getEnvironmentData('SMTP_ERROR') . '>');
+        $this->set('Errors-to', '<' . Controller::getEnvironmentData('SMTP_ERROR') . '>');
         $this->set('MIME-Version', '1.0');
         $this->set('Content-Type', 'text/html; charset=ISO-8859-1');
     }
@@ -35,7 +35,7 @@ class MailController extends \SMTP{
      */
     public function sendDeleteAccount($to, $msg){
         $this->set('To', '<' . $to . '>');
-        $this->set('From', 'Pathfinder <' . Controller::getEnvironmentData('SMTP_FROM') . '>');
+        $this->set('From', '"Pathfinder" <' . Controller::getEnvironmentData('SMTP_FROM') . '>');
         $this->set('Subject', 'Account deleted');
         $status = $this->send($msg);
 

--- a/app/main/controller/mailcontroller.php
+++ b/app/main/controller/mailcontroller.php
@@ -50,7 +50,7 @@ class MailController extends \SMTP{
      */
     public function sendRallyPoint($to, $msg){
         $this->set('To', '<' . $to . '>');
-        $this->set('From', 'Pathfinder <' . Controller::getEnvironmentData('SMTP_FROM') . '>');
+        $this->set('From', '"Pathfinder" <' . Controller::getEnvironmentData('SMTP_FROM') . '>');
         $this->set('Subject', 'PATHFINDER - New rally point');
         $status = $this->send($msg);
 


### PR DESCRIPTION
Issue was introduced by the F3 update to 3.6.0, which changed the email parsing in the SMTP lib. Adding quotes fixes #438.

Verified to be working on self-hosted pathfinder instance with [SparkPost](https://www.sparkpost.com/) SMTP server.