### PR TITLE
Properly quoted database name during USE queries to avoid MySQL parse errors

### DIFF
--- a/app/main/controller/setup.php
+++ b/app/main/controller/setup.php
@@ -925,7 +925,7 @@ class Setup extends Controller {
         $checkTables = [];
         if($db){
             // set/change default "character set" and "collation"
-            $db->exec('ALTER DATABASE ' . $db->name()
+            $db->exec('ALTER DATABASE ' . $db->quotekey($db->name())
                 . ' CHARACTER SET ' . self::getRequiredMySqlVariables('CHARACTER_SET_DATABASE')
                 . ' COLLATE ' . self::getRequiredMySqlVariables('COLLATION_DATABASE')
             );

--- a/app/main/db/sql/mysql/tablemodifier.php
+++ b/app/main/db/sql/mysql/tablemodifier.php
@@ -52,7 +52,7 @@ class TableModifier extends SQL\TableModifier {
             ':constraint_name' => $constraintName
         ]);
         // switch back to current DB
-        $this->db->exec("USE " . $this->db->name());
+        $this->db->exec("USE " . $this->db->quotekey($this->db->name()));
 
         $constraints = [];
         foreach($constraintsData as $data){


### PR DESCRIPTION
As described in #452, special characters such as `-` in database options, especially the database name can cause MySQL parse errors.

This PR fixes this issue by properly quoting the database name.