### PR TITLE
fix unsetting of global map data when in long polling sync mode

### DIFF
--- a/js/app/mappage.js
+++ b/js/app/mappage.js
@@ -256,7 +256,10 @@ define([
                             }
 
                             // map data found
-                            Util.setCurrentMapData(data.mapData);
+                            if(data.mapData !== undefined) {
+                                // store current map data global (cache)
+                                Util.setCurrentMapData(data.mapData);
+                            }
 
                             // load/update main map module
                             ModuleMap.updateMapModule(mapModule).then(() => {

--- a/public/js/v1.3.4/app/mappage.js
+++ b/public/js/v1.3.4/app/mappage.js
@@ -256,7 +256,10 @@ define([
                             }
 
                             // map data found
-                            Util.setCurrentMapData(data.mapData);
+                            if(data.mapData !== undefined) {
+                                // store current map data global (cache)
+                                Util.setCurrentMapData(data.mapData);
+                            }
 
                             // load/update main map module
                             ModuleMap.updateMapModule(mapModule).then(() => {


### PR DESCRIPTION
Looks like df1e54ee5c7c1abb00af9e386a65811cf98c433e broke when in long polling map sync mode

![error](https://user-images.githubusercontent.com/197687/38453031-5fd02406-3a4f-11e8-964d-d5128c322f28.PNG)

Fixed by preventing long pull from unsetting global map data