### PR TITLE
Sort universe search results with Levenshtein's function

### DIFF
--- a/app/main/controller/api/universe.php
+++ b/app/main/controller/api/universe.php
@@ -32,16 +32,6 @@ class Universe extends Controller\AccessController {
             !empty($categories)
         ){
             $universeNameData = Ccp\Universe::searchUniverseNameData($categories, $search);
-
-            foreach($categories as &$category) {
-                if(!empty($universeNameData[$category])){
-                    usort($universeNameData[$category], function($a, $b) use ($search) {
-                        $levA = levenshtein($search, strtolower($a["name"]));
-                        $levB = levenshtein($search, strtolower($b["name"]));
-                        return $levA == $levB ? 0 : ($levA > $levB ? 1 : -1);
-                    });
-                }
-            }
         }
 
         echo json_encode($universeNameData);

--- a/app/main/controller/api/universe.php
+++ b/app/main/controller/api/universe.php
@@ -32,6 +32,16 @@ class Universe extends Controller\AccessController {
             !empty($categories)
         ){
             $universeNameData = Ccp\Universe::searchUniverseNameData($categories, $search);
+
+            foreach($categories as &$category) {
+                if(!empty($universeNameData[$category])){
+                    usort($universeNameData[$category], function($a, $b) use ($search) {
+                        $levA = levenshtein($search, strtolower($a["name"]));
+                        $levB = levenshtein($search, strtolower($b["name"]));
+                        return $levA == $levB ? 0 : ($levA > $levB ? 1 : -1);
+                    });
+                }
+            }
         }
 
         echo json_encode($universeNameData);

--- a/js/app/ui/form_element.js
+++ b/js/app/ui/form_element.js
@@ -334,6 +334,46 @@ define([
             return markup;
         }
 
+        /**
+         * sort universe data
+         * @param data universe search result array
+         * @param term search term
+         */
+        function sortResultData (data, term){
+            let levenshtein = function (a,b){
+                let matrix = new Array(a.length+1);
+                for(let i = 0; i < matrix.length; i++){
+                    matrix[i] = new Array(b.length+1).fill(0);
+                }
+
+                for(let ai = 1; ai <= a.length; ai++){
+                    matrix[ai][0] = ai;
+                }
+
+                for(let bi = 1; bi <= b.length; bi++){
+                    matrix[0][bi] = bi;
+                }
+
+                for(let bi = 1; bi <= b.length; bi++){
+                    for(let ai = 1; ai <= a.length; ai++){
+                        matrix[ai][bi] = Math.min(
+                            matrix[ai-1][bi]+1,
+                            matrix[ai][bi-1]+1,
+                            matrix[ai-1][bi-1]+(a[ai-1] == b[bi-1] ? 0 : 1)
+                        );
+                    }                
+                }
+
+                return matrix[a.length][b.length];
+            };
+
+            data.sort(function(a,b){
+                let levA = levenshtein(term, a.name.toLowerCase());
+                let levB = levenshtein(term, b.name.toLowerCase());
+                return levA === levB ? 0 : (levA > levB ? 1 : -1);
+            });
+        }
+
         return this.each(function() {
             let selectElement = $(this);
 
@@ -370,6 +410,7 @@ define([
                                 for(let category in result){
                                     // skip custom functions in case result = [] (array functions)
                                     if(result.hasOwnProperty(category)){
+                                        sortResultData(result[category], page.term);
                                         data.results.push({
                                             text: category,
                                             children: result[category].map(mapChildren, category)


### PR DESCRIPTION
Fixes ordering of returned list of names from ESI making it more usable (e.g. Owner autocomplete in Intel window).

Results before:
![sortbefore](https://user-images.githubusercontent.com/5772326/43039019-972841ae-8d24-11e8-97e9-abda271feeb3.PNG)

Results after:
![sortafter](https://user-images.githubusercontent.com/5772326/43039020-9d111ae6-8d24-11e8-9a48-995358dd00ca.png)
