### PR TITLE
Added Missing C2 Wandering Hole Sigs

### DIFF
--- a/js/app/conf/signature_type.js
+++ b/js/app/conf/signature_type.js
@@ -140,7 +140,12 @@ define(['jquery'], ($) => {
                 },
                 5: {    // Wormhole
                     // all w-space -> w-space are statics or K162
-                    // all w-space -> k-space are statics or k162
+                    1: 'Z647 - C1',	                    
+                    2: 'D382 - C2',	                    
+                    3: 'O477 - C3',	
+                    4: 'Y683 - C4',	
+                    5: 'N062 - C5',	
+                    6: 'R474 - C6',
                     7: 'F135 - Thera'
                 },
                 6: {    // ORE


### PR DESCRIPTION
Accidental Deletion in last build of PF removed Wandering Sigs for Type C2 Wormholes.