### PR TITLE
Add nvmrc, default to lts/boron

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/boron


### PR DESCRIPTION
`lts/boron` will match 6.x which is what is specified in package.json