### PR TITLE
fixed bug where eveSrcUrl gets called without resourceId.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ package-lock.json
 /public/js/vX.X.X/
 /vendor/
 /history/
+/.vs

--- a/app/Lib/Format/Image.php
+++ b/app/Lib/Format/Image.php
@@ -34,7 +34,7 @@ class Image extends \Prefab {
     /**
      * build image server src URL
      * @param string $resourceType
-     * @param int $resourceId
+     * @param int|null $resourceId
      * @param int|null $size
      * @param string|null $resourceVariant
      * @return string|null

--- a/app/Lib/Format/Image.php
+++ b/app/Lib/Format/Image.php
@@ -39,7 +39,7 @@ class Image extends \Prefab {
      * @param string|null $resourceVariant
      * @return string|null
      */
-    public function eveSrcUrl(string $resourceType, int $resourceId, ?int $size = null, ?string $resourceVariant = null) : ?string {
+    public function eveSrcUrl(string $resourceType, ?int $resourceId = null, ?int $size = null, ?string $resourceVariant = null) : ?string {
         $url = null;
         if(
             $resourceId &&


### PR DESCRIPTION
using /admin/maps sometimes calls eveSrcUrl without resourceId param. This throws an internal 500 server error without this fix.