### PR TITLE
Added check if ResizeObserver() not supported

### DIFF
--- a/js/app/lib/resize.js
+++ b/js/app/lib/resize.js
@@ -5,17 +5,27 @@ define([], () => {
         constructor(config = {}) {
             this._config    = Object.assign({}, ResizeManager.defaultConfig, config);
             this._observables = new WeakMap();
-            this._observer = new ResizeObserver((entries, observer) => { // jshint ignore:line
-                for (let entry of entries) {
-                    if (this._observables.has(entry.target)) {
-                        this._observables
-                            .get(entry.target)
-                            .callback(entry.target, entry.contentRect);
-                    } else {
-                        this._observer.unobserve(entry.target);
+            if(window.ResizeObserver){
+                this._observer = new ResizeObserver((entries, observer) => { // jshint ignore:line
+                    for (let entry of entries) {
+                        if (this._observables.has(entry.target)) {
+                            this._observables
+                                .get(entry.target)
+                                .callback(entry.target, entry.contentRect);
+                        } else {
+                            this._observer.unobserve(entry.target);
+                        }
                     }
-                }
-            });
+                });
+            }else if(requestAnimationFrame){
+                // ResizeObserver() not supported
+                let checkMapSize = (entry) => {
+                    saveMapSize(entry);
+                    return setTimeout(checkMapSize, 500, entry);
+                };
+        
+                checkMapSize(areaMap[0]);
+            }
         }
 
         debounce(callback, ms = this._config.msDebounce, immediate = false) {


### PR DESCRIPTION
Borrowed from https://github.com/exodus4d/pathfinder/blob/62dc991760e3d0bfde078affde20a3fcc6ed2360/js/app/map/map.js#L1130

I got this javascript error on my Firefox ESR for some pathfinders, but not others. It seems not everyone isn on 2.0 yet.
Hopefully I can use all the tools in the same browser again after this :)